### PR TITLE
Add a basic set of tests for 'in_beat' plugin.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,8 +6,9 @@ require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
-  test.test_files = FileList['test/test_*.rb']
-  test.verbose = true
+  test.test_files = FileList['test/plugin/test_*.rb']
+  test.verbose = false
+  test.warning = false
 end
 
 task :default => [:build]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,8 @@
+require 'socket'
+
+def find_available_port
+  s = TCPServer.open(0)
+  port = s.addr[1]
+  s.close
+  return port
+end

--- a/test/plugin/test_in_beats.rb
+++ b/test/plugin/test_in_beats.rb
@@ -1,0 +1,87 @@
+require 'fluent/test'
+require 'fluent/plugin/in_beats'
+require 'lumberjack/beats/client'
+require 'helper'
+
+class BeatsInputTest < Test::Unit::TestCase
+
+  def setup
+    Fluent::Test.setup
+  end
+
+  PORT = find_available_port
+
+  CONFIG = %[
+    port #{PORT}
+    bind 127.0.0.1
+    tag test.beats
+  ]
+
+  def create_driver(conf=CONFIG)
+    Fluent::Test::InputTestDriver.new(Fluent::BeatsInput).configure(conf)
+  end
+
+  def create_client
+    Lumberjack::Beats::Client.new({
+        :port => PORT,
+        :addresses => ['127.0.0.1'],
+        :json => true,
+        :ssl => false
+    })
+  end
+
+  def test_configure
+    d = create_driver
+    assert_equal PORT, d.instance.port
+    assert_equal '127.0.0.1', d.instance.bind
+    assert_equal 'test.beats', d.instance.tag
+  end
+
+  def test_send_beat
+    d = create_driver
+
+    timestamp = '2018-01-01T12:30:00.000Z'
+    payload = {
+        '@metadata' => {'beat' => 'heartbeat'},
+        '@timestamp' => timestamp,
+        'foo' => 'bar'
+    }
+
+    d.run do
+      client = create_client
+      client.write(payload)
+    end
+
+    tag, es = d.emit_streams[0]
+    assert_equal tag, 'test.beats'
+    assert_equal es.length, 1
+
+    time, record = es[0]
+    assert_equal time.to_i, Time.parse(timestamp).to_i
+    assert_equal record, payload
+  end
+
+  def test_metadata_as_tag
+    d = create_driver(CONFIG + 'metadata_as_tag')
+
+    timestamp = '2018-01-01T12:30:00.000Z'
+    payload = {
+        '@metadata' => {'beat' => 'heartbeat'},
+        '@timestamp' => timestamp,
+        'foo' => 'bar'
+    }
+
+    d.run do
+      client = create_client
+      client.write(payload)
+    end
+
+    tag, es = d.emit_streams[0]
+    assert_equal tag, 'heartbeat'
+    assert_equal es.length, 1
+
+    time, record = es[0]
+    assert_equal time.to_i, Time.parse(timestamp).to_i
+    assert_equal record, payload
+  end
+end


### PR DESCRIPTION
### What is this patch?

This patch introduces unit testing to this project.

 - It covers the basic functionality of `Fluent::BeatsInput`.
 - The test scripts added are designed to work both on v0.12 and v1.0.
    - I actually confirmed the test suite runs without problems both on
      Fluentd v0.12.42 and v1.1.2.

These tests might be somewhat helpful when migrating to v1.0 API.

### Note on the context 

This patch was created & submitted, based on the request by @okkez.
