### PR TITLE
adding error router to rescue in event processing

### DIFF
--- a/lib/fluent/plugin/in_beats.rb
+++ b/lib/fluent/plugin/in_beats.rb
@@ -126,6 +126,7 @@ module Fluent::Plugin
           rescue => e
             log.error "unexpected error", :error => e.to_s
             log.error_backtrace
+            router.emit_error_event(tag, time, record, e)
           end
         }
       end


### PR DESCRIPTION
Hi,

According to [the docs](https://docs.fluentd.org/v0.12/articles/plugin-development#error-stream), we should be emitting routing errors via `emit_error_event`. I've noticed that once FluentD hits an error, it doesn't ship it to the output, and it fails to recover. 

However when I modify the plugin to contain this line, it emits the error properly and continues past the error.

Could you please let me know if this is a good or bad idea?

Thank you,