### PR TITLE
Add option ssl_version and ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Configuration example:
 
   Limit the number of connections from beat instances. Default is unlimited.
 
-**use_ssl**, **ssl_certificate**, **ssl_key**, **ssl_key_passphrase**
+**use_ssl**, **ssl_certificate**, **ssl_key**, **ssl_key_passphrase**, **ssl_version**, **ssl_ciphers**
 
   For lumberjack protocol.
 

--- a/lib/fluent/plugin/in_beats.rb
+++ b/lib/fluent/plugin/in_beats.rb
@@ -42,6 +42,8 @@ module Fluent::Plugin
     config_param :ssl_certificate, :string, :default => nil
     config_param :ssl_key, :string, :default => nil
     config_param :ssl_key_passphrase, :string, :default => nil
+    config_param :ssl_version, :string, :default => nil
+    config_param :ssl_ciphers, :string, :default => nil
 
     config_section :parse do
       config_set_default :@type, DEFAULT_PARSER
@@ -75,7 +77,7 @@ module Fluent::Plugin
 
       @lumberjack = Lumberjack::Beats::Server.new(
         :address => @bind, :port => @port, :ssl => @use_ssl, :ssl_certificate => @ssl_certificate,
-        :ssl_key => @ssl_key, :ssl_key_passphrase => @ssl_key_passphrase)
+        :ssl_key => @ssl_key, :ssl_key_passphrase => @ssl_key_passphrase, :ssl_version => @ssl_version, :ssl_ciphers => @ssl_ciphers)
       # Lumberjack::Beats::Server depends on normal accept so we need to launch thread for each connection.
       # TODO: Re-implement Beats Server with Cool.io for resource control
       @thread_pool = Concurrent::CachedThreadPool.new(:idletime => 15) # idletime setting is based on logstash beats input

--- a/lib/lumberjack/beats/server.rb
+++ b/lib/lumberjack/beats/server.rb
@@ -53,8 +53,12 @@ module Lumberjack module Beats
       if @options[:ssl]
         # load SSL certificate
         @ssl = OpenSSL::SSL::SSLContext.new
-        @ssl.ssl_version = @options[:ssl_version]
-        @ssl.ciphers = @options[:ssl_ciphers]
+        if @options[:ssl_version]
+          @ssl.ssl_version = @options[:ssl_version]
+        end
+        if @options[:ssl_ciphers]
+          @ssl.ciphers = @options[:ssl_ciphers]
+        end
         @ssl.cert = OpenSSL::X509::Certificate.new(File.read(@options[:ssl_certificate]))
         @ssl.key = OpenSSL::PKey::RSA.new(File.read(@options[:ssl_key]),
           @options[:ssl_key_passphrase])

--- a/lib/lumberjack/beats/server.rb
+++ b/lib/lumberjack/beats/server.rb
@@ -29,7 +29,9 @@ module Lumberjack module Beats
         :ssl => true,
         :ssl_certificate => nil,
         :ssl_key => nil,
-        :ssl_key_passphrase => nil
+        :ssl_key_passphrase => nil,
+        :ssl_version => nil,
+        :ssl_ciphers => nil,
       }.merge(options)
 
       if @options[:ssl]
@@ -51,6 +53,8 @@ module Lumberjack module Beats
       if @options[:ssl]
         # load SSL certificate
         @ssl = OpenSSL::SSL::SSLContext.new
+        @ssl.ssl_version = @options[:ssl_version]
+        @ssl.ciphers = @options[:ssl_ciphers]
         @ssl.cert = OpenSSL::X509::Certificate.new(File.read(@options[:ssl_certificate]))
         @ssl.key = OpenSSL::PKey::RSA.new(File.read(@options[:ssl_key]),
           @options[:ssl_key_passphrase])


### PR DESCRIPTION
Usage:
```
<source>
  @type beats
  metadata_as_tag
  ssl_version TLSv1_2
  ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
   ...
</source>

```